### PR TITLE
Update xdrv_22_sonoff_ifan.ino

### DIFF
--- a/tasmota/xdrv_22_sonoff_ifan.ino
+++ b/tasmota/xdrv_22_sonoff_ifan.ino
@@ -27,8 +27,8 @@
 const uint8_t MAX_FAN_SPEED = 4;            // Max number of iFan02 fan speeds (0 .. 3)
 
 const uint8_t kIFan02Speed[MAX_FAN_SPEED] = { 0x00, 0x01, 0x03, 0x05 };
-const uint8_t kIFan03Speed[MAX_FAN_SPEED +2] = { 0x00, 0x01, 0x03, 0x04, 0x05, 0x06 };
-const uint8_t kIFan03Sequence[MAX_FAN_SPEED][MAX_FAN_SPEED] = {{0, 2, 2, 2}, {0, 1, 2, 4}, {1, 1, 2, 5}, {4, 4, 5, 3}};
+const uint8_t kIFan03Speed[MAX_FAN_SPEED +2] = { 0x00, 0x01, 0x02, 0x04, 0x05, 0x06 };
+const uint8_t kIFan03Sequence[MAX_FAN_SPEED][MAX_FAN_SPEED] = {{0, 4, 5, 3}, {0, 1, 2, 3}, {0, 1, 2, 3}, {0, 4, 5, 3}};
 
 const char kSonoffIfanCommands[] PROGMEM = "|"  // No prefix
   D_CMND_FANSPEED;


### PR DESCRIPTION
We need to change the way the relays are switched from the default way which is incorrect.

Slow (1) – relay 1 on 2 & 3 off
Medium (2) relay 1 & 2 on 3 off
Fast (3) relay 3 on 1 & 2 off

This behaviour does not give the correct speed control. To get the correct speed control we need the relays to switch as follows.

Slow (1) – relay 1 on 2 & 3 off
Medium (2) relay 2 on 1 & 3 off
Fast (3) relay 3 on 1 & 2 off

Another important feature we want to implement is that when you turn on the fan from the slow or medium speeds the hi speed relay is engaged briefly before switching to the speed that was selected. This is done to give the fan maximum power to get moving, this will save the inrush current from going through the capacitors and increase their life.

For more details see https://www.breznet.com/2021/07/31/sonoff-ifan03/

## Description:

**Related issue (if applicable):** fixes #<Tasmota issue number goes here>

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [x] The code change is tested and works with Tasmota core ESP8266 V.2.7.4.9
  - [ ] The code change is tested and works with Tasmota core ESP32 V.1.0.7.2
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
